### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing to Wirefy
+# Contributing to Wirefy
 =================
 ♥ [Wirefy](http://getwirefy.com) and want to get involved?
 We would love that and you've made us blush. First thank you so much. Now there are plenty of ways you can help.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Creating static wireframes can be great but sometimes clients just don't underst
 Clone the git repo - `git clone git://github.com/cjdsie/wirefy.git` - or [download it](https://github.com/cjdsie/wirefy/zipball/master)
 
 
-##Getting started
+## Getting started
 
 This framework using Node.js, NPM (Node Package Manager), and Grunt.js to manage the code in this repo. Please make sure that you have these installed to begin with. In order to get started with Grunt, you must install the Grunt command line interface (CLI) globally `npm install -g grunt-cli`. This will give you the ability to use the grunt development tasks found in the Gruntfile.js file. To preview code locally, you'll need to install Node and NPM, then run the following commands from a terminal window, in the repo directory: 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
